### PR TITLE
fix: exclusion par tableau et bug au spam aiming

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,28 +1,29 @@
+local ExcludeWeapons ={ "HEAVYSNIPER", "MARKSMANRIFLE" }
 
 CreateThread(function()
     local t
 
     while (function()
-        t =500
+        t =250
         local playerPed =PlayerPedId()
-
+				
         if not IsPlayerFreeAiming(PlayerId()) then
-          return true
+        	return true
         end
+		
+	local currentWeaponHash = GetSelectedPedWeapon(playerPed)
 
-        for weapon = 1, 6 do
-            if IsPedArmed(playerPed, weapon) then
-                local currentWeaponHash = GetSelectedPedWeapon(playerPed)
+	for _, weapon in ipairs(ExcludeWeapons) do
+		if currentWeaponHash == GetHashKey(("WEAPON_%s"):format(weapon)) then
+			return true
+		end
+	end
 
-                if currentWeaponHash == GetHashKey("WEAPON_HEAVYSNIPER") or currentWeaponHash == GetHashKey("WEAPON_MARKSMANRIFLE") then
-                    return true
-                end
-                t =1
-                HideHudComponentThisFrame(14)
-                return true
-            end
-        end
-		return true
+	t =1
+
+	HideHudComponentThisFrame(14)
+				
+	return true
     end)() do
         Wait(t)
     end


### PR DESCRIPTION
— Ranger les armes exclues du process dans un tableau à parcourir
— Lors du spam clic droit, le réticule pouvait apparaître, t passé à 250 au lieu de 500